### PR TITLE
Fix default glob not matching files in directories

### DIFF
--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -2,7 +2,7 @@ import pkg from '../../package.json' with { type: 'json' };
 import type { ExecStagedConfigEntry } from '../types.js';
 
 export const DEFAULT_CONFIG_ENTRY: Omit<ExecStagedConfigEntry, 'task'> = {
-  glob: '*',
+  glob: '**',
   diff: 'ACMR',
 };
 


### PR DESCRIPTION
Currently, $FILES includes `eslint.config.js` but not `src/index.ts`.