### PR TITLE
Fix git version support (`v2.22.0`)

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ npm install --save-dev exec-staged
 
 ## Requirements
 
-- Git >= 2.41.0
+- Git > 2.13.0
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ npm install --save-dev exec-staged
 
 ## Requirements
 
-- Git >= 2.13.0
+- Git >= 2.22.0
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ npm install --save-dev exec-staged
 
 ## Requirements
 
-- Git > 2.13.0
+- Git >= 2.13.0
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ Install from npm, using your preferred package manager:
 npm install --save-dev exec-staged
 ```
 
+## Requirements
+
+- Git >= 2.41.0
+
 ## Usage
 
 ### Run from the CLI

--- a/src/lib/stage.ts
+++ b/src/lib/stage.ts
@@ -85,7 +85,7 @@ export class Stage {
       throw new Error('git installation not found');
     }
 
-    if (!version || semver.lte(version, '2.13.0')) {
+    if (!version || semver.lt(version, '2.13.0')) {
       this.logger.log('⚠️ Unsupported git version!');
       throw new Error('unsupported git version');
     }

--- a/src/lib/stage.ts
+++ b/src/lib/stage.ts
@@ -85,7 +85,7 @@ export class Stage {
       throw new Error('git installation not found');
     }
 
-    if (!version || semver.lt(version, '2.13.0')) {
+    if (!version || semver.lt(version, '2.22.0')) {
       this.logger.log('⚠️ Unsupported git version!');
       throw new Error('unsupported git version');
     }

--- a/src/lib/stage.ts
+++ b/src/lib/stage.ts
@@ -85,7 +85,7 @@ export class Stage {
       throw new Error('git installation not found');
     }
 
-    if (!version || semver.lte(version, '2.13.0')) {
+    if (!version || semver.lt(version, '2.41.0')) {
       this.logger.log('⚠️ Unsupported git version!');
       throw new Error('unsupported git version');
     }

--- a/src/lib/stage.ts
+++ b/src/lib/stage.ts
@@ -85,7 +85,7 @@ export class Stage {
       throw new Error('git installation not found');
     }
 
-    if (!version || semver.lt(version, '2.41.0')) {
+    if (!version || semver.lte(version, '2.13.0')) {
       this.logger.log('⚠️ Unsupported git version!');
       throw new Error('unsupported git version');
     }
@@ -185,7 +185,8 @@ export class Stage {
       this.git([
         'diff',
         '--binary',
-        '--default-prefix',
+        '--src-prefix=a/',
+        '--dst-prefix=b/',
         // skip deleted files because patch doesn't apply if they're modified
         '--diff-filter=d',
         '--no-color',

--- a/test/stage.ts
+++ b/test/stage.ts
@@ -34,7 +34,7 @@ describe('Stage', () => {
     });
 
     it('throws if git version is unsupported', async () => {
-      stage.writeFile('.fake-bin/git', '#!/bin/sh\necho "git version 2.40.0"');
+      stage.writeFile('.fake-bin/git', '#!/bin/sh\necho "git version 2.12.0"');
       stage.chmod('.fake-bin/git', 0o755);
 
       // override git to prefer the fake script that reports an old version

--- a/test/stage.ts
+++ b/test/stage.ts
@@ -34,7 +34,7 @@ describe('Stage', () => {
     });
 
     it('throws if git version is unsupported', async () => {
-      stage.writeFile('.fake-bin/git', '#!/bin/sh\necho "git version 2.12.0"');
+      stage.writeFile('.fake-bin/git', '#!/bin/sh\necho "git version 2.21.999"');
       stage.chmod('.fake-bin/git', 0o755);
 
       // override git to prefer the fake script that reports an old version

--- a/test/stage.ts
+++ b/test/stage.ts
@@ -34,7 +34,7 @@ describe('Stage', () => {
     });
 
     it('throws if git version is unsupported', async () => {
-      stage.writeFile('.fake-bin/git', '#!/bin/sh\necho "git version 2.12.0"');
+      stage.writeFile('.fake-bin/git', '#!/bin/sh\necho "git version 2.40.0"');
       stage.chmod('.fake-bin/git', 0o755);
 
       // override git to prefer the fake script that reports an old version


### PR DESCRIPTION
Removed `--default-prefix` which was introduced in `v2.41.0`.  Raised min git version to `v2.22.0` to support `--no-rename-empty`.