### PR TITLE
Skip `git apply` for empty patch files

### DIFF
--- a/src/lib/stage.ts
+++ b/src/lib/stage.ts
@@ -311,16 +311,19 @@ export class Stage {
         STAGED_CHANGES_COMMIT_MESSAGE,
       ]);
 
-      // apply patch containing unstaged changes
-      this.git([
-        'apply',
-        '--allow-empty',
-        '--recount',
-        '--unidiff-zero',
-        '--whitespace=nowarn',
-        '--3way',
-        this.patchPath,
-      ]);
+      // apply patch containing unstaged changes.
+      // `--allow-empty` could be used here, but it was not added to `git apply`
+      // until 2.35.0 (January 2022), so we skip the call when the patch is empty.
+      if (fs.statSync(this.patchPath).size > 0) {
+        this.git([
+          'apply',
+          '--recount',
+          '--unidiff-zero',
+          '--whitespace=nowarn',
+          '--3way',
+          this.patchPath,
+        ]);
+      }
 
       // unstaged deletions are not included in the patch and must be handled
       // separately because the patch cannot be applied if such files are

--- a/test/stage.ts
+++ b/test/stage.ts
@@ -34,7 +34,10 @@ describe('Stage', () => {
     });
 
     it('throws if git version is unsupported', async () => {
-      stage.writeFile('.fake-bin/git', '#!/bin/sh\necho "git version 2.21.999"');
+      stage.writeFile(
+        '.fake-bin/git',
+        '#!/bin/sh\necho "git version 2.21.999"',
+      );
       stage.chmod('.fake-bin/git', 0o755);
 
       // override git to prefer the fake script that reports an old version
@@ -717,6 +720,36 @@ describe('Stage', () => {
       stage.git(['commit', '-m', 'add file']);
       stage.rename('test.old', 'test.new');
       stage.git(['add', 'test.old', 'test.new']);
+
+      const oldStatus = stage.git(['status', '-z']);
+      stage.prepare();
+      stage.merge();
+      const newStatus = stage.git(['status', '-z']);
+
+      assert.equal(newStatus, oldStatus);
+    });
+
+    it('applies empty patch when only staged changes exist', async () => {
+      // When there are no unstaged changes, `git diff` produces an empty patch.
+      // `git apply --allow-empty` is required so this does not error.
+      stage.writeFile('test.txt');
+      stage.git(['add', 'test.txt']);
+
+      const oldStatus = stage.git(['status', '-z']);
+      stage.prepare();
+      stage.merge();
+      const newStatus = stage.git(['status', '-z']);
+
+      assert.equal(newStatus, oldStatus);
+    });
+
+    it('applies empty patch when only unstaged deletions exist', async () => {
+      // Unstaged deletions are excluded from the patch by `--diff-filter=d`,
+      // so the patch is empty. `git apply --allow-empty` is required.
+      stage.writeFile('test.txt', 'old contents');
+      stage.git(['add', 'test.txt']);
+      stage.git(['commit', '-m', 'add file']);
+      stage.rm('test.txt');
 
       const oldStatus = stage.git(['status', '-z']);
       stage.prepare();

--- a/test/stage.ts
+++ b/test/stage.ts
@@ -34,10 +34,7 @@ describe('Stage', () => {
     });
 
     it('throws if git version is unsupported', async () => {
-      stage.writeFile(
-        '.fake-bin/git',
-        '#!/bin/sh\necho "git version 2.21.999"',
-      );
+      stage.writeFile('.fake-bin/git', '#!/bin/sh\necho "git version 2.21.999"');
       stage.chmod('.fake-bin/git', 0o755);
 
       // override git to prefer the fake script that reports an old version
@@ -720,36 +717,6 @@ describe('Stage', () => {
       stage.git(['commit', '-m', 'add file']);
       stage.rename('test.old', 'test.new');
       stage.git(['add', 'test.old', 'test.new']);
-
-      const oldStatus = stage.git(['status', '-z']);
-      stage.prepare();
-      stage.merge();
-      const newStatus = stage.git(['status', '-z']);
-
-      assert.equal(newStatus, oldStatus);
-    });
-
-    it('applies empty patch when only staged changes exist', async () => {
-      // When there are no unstaged changes, `git diff` produces an empty patch.
-      // `git apply --allow-empty` is required so this does not error.
-      stage.writeFile('test.txt');
-      stage.git(['add', 'test.txt']);
-
-      const oldStatus = stage.git(['status', '-z']);
-      stage.prepare();
-      stage.merge();
-      const newStatus = stage.git(['status', '-z']);
-
-      assert.equal(newStatus, oldStatus);
-    });
-
-    it('applies empty patch when only unstaged deletions exist', async () => {
-      // Unstaged deletions are excluded from the patch by `--diff-filter=d`,
-      // so the patch is empty. `git apply --allow-empty` is required.
-      stage.writeFile('test.txt', 'old contents');
-      stage.git(['add', 'test.txt']);
-      stage.git(['commit', '-m', 'add file']);
-      stage.rm('test.txt');
 
       const oldStatus = stage.git(['status', '-z']);
       stage.prepare();


### PR DESCRIPTION
closes #17 

This PR adds branching to skip `git apply` entirely if the patch file is empty.  The built-in `--allow-empty` option was added in git `2.35.0`, which some users have still not upgraded to.

In a few more years we can revert this PR and increase the minimum required git version.