### PR TITLE
Verify cwd git dir via git prefix

### DIFF
--- a/src/lib/stage.ts
+++ b/src/lib/stage.ts
@@ -90,16 +90,16 @@ export class Stage {
       throw new Error('unsupported git version');
     }
 
-    let gitRootDirectory: string;
+    let prefix: string;
 
     try {
-      gitRootDirectory = this.git(['rev-parse', '--show-toplevel']).trim();
+      prefix = this.git(['rev-parse', '--show-prefix']).trim();
     } catch (error) {
       this.logger.log('⚠️ Not a git repository!');
       throw new Error('cwd is not a git repository');
     }
 
-    if (gitRootDirectory !== this.cwd) {
+    if (prefix !== '') {
       this.logger.log('⚠️ Not in git root directory!');
       throw new Error('cwd is not a git repository root directory');
     }


### PR DESCRIPTION
>     fix: use git rev-parse --show-prefix to avoid symlink path mismatch on macOS
>     
>     On macOS, /var is a symlink to /private/var. Older git versions
>     resolve this when returning --show-toplevel, causing a string
>     mismatch against Node's unresolved cwd path. --show-prefix avoids
>     the issue entirely by comparing relative paths instead of absolute
>     ones.
>     
>     Fixes test failures on macOS with older git versions.
